### PR TITLE
Use inclusive naming for uplugin lists

### DIFF
--- a/Linter/Linter.uplugin
+++ b/Linter/Linter.uplugin
@@ -17,12 +17,12 @@
 			"Name": "Linter",
 			"Type": "Editor",
 			"LoadingPhase": "PreDefault",
-			"WhitelistPlatforms": [
+			"PlatformAllowList": [
 				"Win64",
 				"Mac",
 				"Linux"
 			],
-			"BlacklistTargets": [
+			"TargetDenyList": [
 				"Server",
 				"Client"
 			]
@@ -31,12 +31,12 @@
 			"Name": "GamemakinLinter",
 			"Type": "Editor",
 			"LoadingPhase": "PreDefault",
-			"WhitelistPlatforms": [
+			"PlatformAllowList": [
 				"Win64",
 				"Mac",
 				"Linux"
 			],
-			"BlacklistTargets": [
+			"TargetDenyList": [
 				"Server",
 				"Client"
 			]
@@ -45,12 +45,12 @@
 			"Name": "MarketplaceLinter",
 			"Type": "Editor",
 			"LoadingPhase": "PreDefault",
-			"WhitelistPlatforms": [
+			"PlatformAllowList": [
 				"Win64",
 				"Mac",
 				"Linux"
 			],
-			"BlacklistTargets": [
+			"TargetDenyList": [
 				"Server",
 				"Client"
 			]


### PR DESCRIPTION
Replaced names are marked deprecated in the engine.
Based on the https://dev.epicgames.com/documentation/en-us/unreal-engine/epic-cplusplus-coding-standard-for-unreal-engine#inclusivewordchoice